### PR TITLE
update

### DIFF
--- a/install.js
+++ b/install.js
@@ -2,43 +2,56 @@ module.exports = {
   requires: {
     bundle: "ai",
   },
-  run: [{
-    method: "shell.run",
-    params: {
-      path: "app",
-        env: {
-          UV_VENV_CLEAR: "1"
-        },
-      message: [
-        "uv venv --relocatable --prompt invoke --python 3.12 --python-preference only-managed env",
-      ]
-    }
-  }, {
-    method: "script.start",
-    params: {
-      uri: "torch.js",
+  run: [
+    {
+      when: "{{platform === 'win32' && gpu === 'amd'}}",
+      method: "notify",
       params: {
-        venv: "env",
-        path: "app"
+        html: "This app is not compatible with AMD on Windows."
+      },
+      next: null
+    },
+    {
+      method: "shell.run",
+      params: {
+        path: "app",
+          env: {
+            UV_VENV_CLEAR: "1"
+          },
+        message: [
+          "uv venv --relocatable --prompt invoke --python 3.12 --python-preference only-managed env",
+        ]
+      }
+    },
+    {
+      method: "script.start",
+      params: {
+        uri: "torch.js",
+        params: {
+          venv: "env",
+          path: "app"
+        }
+      }
+    },
+    {
+      method: "fs.link",
+      params: {
+        drive: {
+          "models": "app/models",
+          "databases": "app/databases",
+          "autoimport": "app/autoimport",
+          "outputs": "app/outputs",
+          "nodes": "app/nodes",
+          "text-inversion-output": "app/text-inversion-output",
+          "text-inversion-training-data": "app/text-inversion-training-data"
+        }
+      }
+    },
+    {
+      method: "notify",
+      params: {
+        html: "App launched. Click 'start' to get started"
       }
     }
-  }, {
-    method: "fs.link",
-    params: {
-      drive: {
-        "models": "app/models",
-        "databases": "app/databases",
-        "autoimport": "app/autoimport",
-        "outputs": "app/outputs",
-        "nodes": "app/nodes",
-        "text-inversion-output": "app/text-inversion-output",
-        "text-inversion-training-data": "app/text-inversion-training-data"
-      }
-    }
-  }, {
-    method: "notify",
-    params: {
-      html: "App launched. Click 'start' to get started"
-    }
-  }]
+  ]
 }

--- a/torch.js
+++ b/torch.js
@@ -7,17 +7,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install -U \"InvokeAI[xformers]\" --python 3.12 --python-preference only-managed --index=https://download.pytorch.org/whl/cu128 --reinstall"
-      }
-    },
-    // windows amd
-    {
-      "when": "{{platform === 'win32' && gpu === 'amd'}}",
-      "method": "shell.run",
-      "params": {
-        "venv": "{{args && args.venv ? args.venv : null}}",
-        "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install -U torch-directml torchaudio torchvision numpy==1.26.4"
+        "message": "uv pip install -U invokeai --python 3.12 --python-preference only-managed --torch-backend=cu128 --reinstall"
       }
     },
     // windows cpu
@@ -27,7 +17,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install -U InvokeAI --python 3.12 --python-preference only-managed --index=https://download.pytorch.org/whl/cpu --reinstall"
+        "message": "uv pip install -U invokeai --python 3.12 --python-preference only-managed --reinstall"
       }
     },
     // apple mac
@@ -37,7 +27,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install -U InvokeAI --python 3.12 --python-preference only-managed --index=https://download.pytorch.org/whl/cpu --reinstall"
+        "message": "uv pip install -U invokeai --python 3.12 --python-preference only-managed --reinstall"
       }
     },
     // intel mac
@@ -47,7 +37,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install -U InvokeAI --python 3.12 --python-preference only-managed --index=https://download.pytorch.org/whl/cpu --reinstall"
+        "message": "uv pip install -U invokeai --python 3.12 --python-preference only-managed --reinstall"
       }
     },
     // linux nvidia
@@ -57,7 +47,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install -U \"InvokeAI[xformers]\" --python 3.12 --python-preference only-managed --index=https://download.pytorch.org/whl/cu128 --reinstall"
+        "message": "uv pip install -U invokeai --python 3.12 --python-preference only-managed ---torch-backend=cu128 --reinstall"
       }
     },
     // linux rocm (amd)
@@ -67,7 +57,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install -U InvokeAI --python 3.12 --python-preference only-managed --index=https://download.pytorch.org/whl/rocm6.2.4 --reinstall"
+        "message": "uv pip install -U invokeai --python 3.12 --python-preference only-managed --torch-backend=rocm6.3 --reinstall"
       }
     },
     // linux cpu
@@ -77,7 +67,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install -U InvokeAI --python 3.12 --python-preference only-managed --index=https://download.pytorch.org/whl/cpu --reinstall"
+        "message": "uv pip install -U invokeai --python 3.12 --python-preference only-managed --torch-backend=cpu --reinstall"
       }
     }
   ]


### PR DESCRIPTION
- incompatibility notification for windows amd
- use `--torch-backend` instead of index url
- rocm6.3 for linux amd
- no torch backend for mac and windows cpu
See [Invoke - Manual Installation](https://invoke.ai/start-here/manual/#walkthrough)

side note: runs with bluefariy protection enabled